### PR TITLE
Try to mock imports from _libxtb extension for rtd

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,8 @@ napoleon_google_docstring = False
 napoleon_use_param = False
 napoleon_use_ivar = True
 
+autodoc_mock_imports = ["xtb.libxtb"]
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/xtb/interface.py
+++ b/xtb/interface.py
@@ -20,10 +20,8 @@ from typing import List, Optional
 from enum import Enum, auto
 import numpy as np
 
-try:
-    from ._libxtb import ffi as _ffi, lib as _lib
-except ImportError:
-    raise ImportError("xtb C extension unimportable, cannot use C-API")
+
+from .libxtb import ffi as _ffi, lib as _lib
 
 
 def get_api_version() -> str:

--- a/xtb/libxtb.py
+++ b/xtb/libxtb.py
@@ -1,0 +1,21 @@
+# This file is part of xtb.
+#
+# Copyright (C) 2020 Sebastian Ehlert
+#
+# xtb is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# xtb is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with xtb.  If not, see <https://www.gnu.org/licenses/>.
+
+try:
+    from ._libxtb import ffi, lib
+except ImportError:
+    raise ImportError("xtb C extension unimportable, cannot use C-API")


### PR DESCRIPTION
Documentation is currently incomplete due to missing `_libxtb` extension.

Solution: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_mock_imports