### PR TITLE
Add OSX support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,22 +18,17 @@ matrix:
     - os: osx
       osx_image: xcode11.5
       language: generic
-      env: CC=clang FC=gfortran-8 OMP=false
-
-    - os: osx
-      osx_image: xcode11.5
-      language: generic
-      env: CC=gcc-8 FC=gfortran-8 OMP=true
+      env: CC=gcc-8 FC=gfortran-8
 
     - os: linux
       dist: bionic
       python: 3.6
-      env: CC=gcc-7 FC=gfortran-7 OMP=true
+      env: CC=gcc-7 FC=gfortran-7
 
     - os: linux
       dist: bionic
       python: 3.8
-      env: CC=gcc-8 FC=gfortran-8 OMP=true
+      env: CC=gcc-8 FC=gfortran-8
 
 
 before_install:
@@ -43,9 +38,9 @@ before_install:
    - python3 -V
 
 install:
-   - pip3 install -U meson==0.53.2 ninja pytest pytest-cov codecov
+   - pip3 install -U meson ninja pytest pytest-cov codecov
    - if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi
-   - meson setup build --prefix=$PWD --libdir=xtb -Dla_backend=netlib -Dopenmp=$OMP
+   - meson setup build --prefix=$PWD --libdir=xtb -Dla_backend=netlib
    - ninja -C build install
    - pip3 install -e .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,56 @@
 language: python
-python:
-   - 3.7
-   - 3.8
 
-os: linux
-dist: bionic
 addons:
    apt:
       packages:
          - libblas-dev
          - liblapack-dev
-         - gfortran
+         - gfortran-7
+         - gfortran-8
          - python-pip
+   homebrew:
+      packages:
+         - gcc@8
+
+matrix:
+  include:
+
+    - os: osx
+      osx_image: xcode11.5
+      language: generic
+      env: CC=clang FC=gfortran-8 OMP=false
+
+    - os: osx
+      osx_image: xcode11.5
+      language: generic
+      env: CC=gcc-8 FC=gfortran-8 OMP=true
+
+    - os: linux
+      dist: bionic
+      python: 3.6
+      env: CC=gcc-7 FC=gfortran-7 OMP=true
+
+    - os: linux
+      dist: bionic
+      python: 3.8
+      env: CC=gcc-8 FC=gfortran-8 OMP=true
+
 
 before_install:
    - uname -a
    - df -h
    - ulimit -a
-   - python -V
+   - python3 -V
 
 install:
-   - pip3 install -U meson ninja pytest pytest-cov codecov
+   - pip3 install -U meson==0.53.2 ninja pytest pytest-cov codecov
    - if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi
-   - meson setup build --prefix=$PWD --libdir=xtb -Dla_backend=netlib
+   - meson setup build --prefix=$PWD --libdir=xtb -Dla_backend=netlib -Dopenmp=$OMP
    - ninja -C build install
-   - pip install -e .
+   - pip3 install -e .
 
 script:
-   - pytest -v --cov=xtb --pyargs xtb
+   - OMP_NUM_THREADS=2,1 pytest -v --cov=xtb --pyargs xtb
 
 after_success:
    - codecov


### PR DESCRIPTION
OSX support for the C-API has not been tested up to now, so there is no guarantee for it to work at all.

Tested so far:

- clang (XCode 11.5 + gfortran-8 from homebrew, default-library=static) fails to link
- GCC 7.5.0 (homebrew, default-library=static) fails unpredictable with segfaults
- GCC 8.4.0 (homebrew, default-library=static) does not pass tests
- GCC 7.5.0 (conda-forge, default-library=shared) fails unpredictable with segfaults

Due to lacking physical access to a Mac this is quite hard to debug and has therefore rather low priority. Any contributions to this effort are more than welcome.