### PR TITLE
Update docs to include conda-forge installation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 Python API for the extended tight binding program
 =================================================
 
+.. image:: https://img.shields.io/conda/vn/conda-forge/xtb-python.svg
+   :alt: Conda Version
+   :target: https://anaconda.org/conda-forge/xtb-python
 .. image:: https://img.shields.io/github/license/grimme-lab/xtb-python
    :alt: License
    :target: COPYING.LESSER
@@ -25,6 +28,39 @@ requiring an additional ``xtb`` installation.
 
 Installation
 ------------
+
+Depending on what you plan to do with ``xtb-python`` there are two recommended
+ways to install. If you plan to use this project in your workflows, proceed
+with the conda installation, if you plan to develop on this project, proceed
+with the build from source.
+
+For more details visit the `documentation <https://xtb-python.readthedocs.io/en/latest/installation.html>`_.
+
+
+With Conda
+~~~~~~~~~~
+
+Installing ``xtb-python`` from the ``conda-forge`` channel can be achieved by adding ``conda-forge`` to your channels with:
+
+.. code::
+
+   conda config --add channels conda-forge
+
+Once the ``conda-forge`` channel has been enabled, ``xtb-python`` can be installed with:
+
+.. code::
+
+   conda install xtb-python
+
+It is possible to list all of the versions of ``xtb-python`` available on your platform with:
+
+.. code::
+
+   conda search xtb-python --channel conda-forge
+
+
+From Source
+~~~~~~~~~~~
 
 When building this project from source, make sure to initialize the git submodules
 with
@@ -62,8 +98,6 @@ as usual with
 .. code::
 
    pip install -e .
-
-For more details visit the `documentation <https://xtb-python.readthedocs.io/en/latest/installation.html>`_.
 
 
 Contributing

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -30,6 +30,8 @@ For more details on the ``xtb`` API dependency see :ref:`building`.
 Installation with Conda
 -----------------------
 
+For details on how to setup conda look up the `conda documentation <https://docs.conda.io>`_.
+
 Installing ``xtb-python`` from the conda-forge channel can be achieved by adding conda-forge to your channels with:
 
 .. code-block:: none

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,10 +3,16 @@
 Installation
 ============
 
-For the basic functionalities the ``xtb-python`` project requires following
-packages:
+Depending on what you plan to do with ``xtb-python`` there are two recommended ways to install.
 
-.. code::
+If you plan to use this project in your workflows, proceed with the :ref:`conda-forge`.
+If you plan to develop on this project, proceed with :ref:`building`.
+
+.. contents::
+
+For the basic functionalities the ``xtb-python`` project requires following packages:
+
+.. code-block:: none
 
    cffi
    numpy
@@ -19,6 +25,36 @@ Depending on how ``xtb-python`` was packaged it requires an installation of ``xt
 For more details on the ``xtb`` API dependency see :ref:`building`.
 
 
+.. _conda-forge:
+
+Installation with Conda
+-----------------------
+
+Installing ``xtb-python`` from the conda-forge channel can be achieved by adding conda-forge to your channels with:
+
+.. code-block:: none
+
+   conda config --add channels conda-forge
+
+Once the conda-forge channel has been enabled, ``xtb-python`` can be installed with:
+
+.. code-block:: none
+
+   conda install xtb-python
+
+It is possible to list all of the versions of ``xtb-python`` available on your platform with:
+
+.. code-block:: none
+
+   conda search xtb-python --channel conda-forge
+
+To install the additional dependencies for ASE and QCArchive integration use
+
+.. code-block:: none
+
+   conda install qcelemental ase
+
+
 .. _building:
 
 Building from Source
@@ -26,7 +62,7 @@ Building from Source
 
 To install ``xtb-python`` from source clone the repository from GitHub with
 
-.. code::
+.. code-block:: none
 
    git clone https://github.com/grimme-lab/xtb-python
    cd xtb-python
@@ -41,7 +77,7 @@ Building the Extension Module
 To work with ``xtb-python`` it is necessary to build the extension to the ``xtb`` API first, this is accomplised by using meson and the C foreign function interface (CFFI).
 Following modules should be available to build this project:
 
-.. code::
+.. code-block:: none
 
    cffi
    numpy
@@ -50,21 +86,21 @@ Following modules should be available to build this project:
 To install the meson build system first check your package manager for an up-to-date meson version, usually this will also install ninja as dependency.
 Alternatively, you can install the latest version of meson and ninja with ``pip`` (or ``pip3`` depending on your system):
 
-.. code::
+.. code-block:: none
 
    pip install cffi numpy meson ninja
 
 If you prefer ``conda`` as a package manage you can install meson and ninja from the conda-forge channel.
 Make sure to select the conda-forge channel for searching packages.
 
-.. code::
+.. code-block:: none
 
    conda config --add channels conda-forge
    conda install cffi numpy meson ninja
 
 Now, setup the project by building the CFFI extension module from the ``xtb`` API with:
 
-.. code::
+.. code-block:: none
 
    meson setup build --prefix=$PWD --libdir=xtb --default-library=shared
    ninja -C build install
@@ -77,14 +113,14 @@ Meson cannot find xtb dependency
 
 If meson cannot find your ``xtb`` installation check if you have ``pkg-config`` installed and that ``xtb`` can be found using
 
-.. code::
+.. code-block:: none
 
    pkg-config xtb --print-errors
 
 In case this fails ensure that the ``xtb.pc`` file is in a directory in the ``PKG_CONFIG_PATH`` and retry.
 For the official release tarball you possible have to edit the first line of ``xtb.pc`` to point to the location where you installed ``xtb``:
 
-.. code:: diff
+.. code-block:: diff
 
    --- a/lib/pkgconfig/xtb.pc
    +++ b/lib/pkgconfig/xtb.pc
@@ -113,7 +149,7 @@ Installing in Development Mode
 
 After creating the ``_libxtb`` extension, the Python module can be installed as usual with
 
-.. code::
+.. code-block:: none
 
    pip install -e .
 
@@ -126,13 +162,13 @@ You can test your setup by opening a new Python interpreter and try to import th
 
 If you also want to use extensions install with
 
-.. code::
+.. code-block:: none
 
    pip install -e '.[ase,qcschema]'
 
 Now you can test your installation with
 
-.. code::
+.. code-block:: none
 
    pytest --pyargs xtb
 
@@ -159,7 +195,7 @@ For convenience we also offer a mode to work without an upstream ``xtb`` depende
 For this approach we follow the same scheme as with the normal extension build.
 You will need the following packages installed
 
-.. code::
+.. code-block:: none
 
    cffi
    numpy
@@ -169,7 +205,7 @@ Additionally you will need a development version of Python, for the Python heade
 
 We closely follow the approach from before, but we change the configuration of the extension build to
 
-.. code::
+.. code-block:: none
 
    meson setup build --prefix=$PWD --libdir=xtb --default-library=static
    ninja -C build install


### PR DESCRIPTION
`xtb-python` is now up on conda-forge: https://anaconda.org/conda-forge/xtb-python