### PR TITLE
Add note about unit conversions to API docs

### DIFF
--- a/docs/general-api.rst
+++ b/docs/general-api.rst
@@ -3,6 +3,11 @@
 API Documentation
 =================
 
+.. important::
+
+   All properties exchanged with the ``xtb`` API are given in `atomic units <https://en.wikipedia.org/wiki/Hartree_atomic_units>`_.
+   For integrations with other frameworks the unit conventions might differ and require conversion.
+
 .. contents::
 
 Calculation Environment


### PR DESCRIPTION
`xtb` API requires and provides all quantities in atomic units. This PR adds a note in a prominent spot in the documentation.