### PR TITLE
Fix version testing

### DIFF
--- a/xtb/libxtb.py
+++ b/xtb/libxtb.py
@@ -40,8 +40,8 @@ VERBOSITY_MUTED = 0
 
 
 def get_api_version() -> str:
-    """Return the current API version from xtb, for easy usage in C
-    the API version is provided as
+    """Return the current API version from xtb.
+    For easy usage in C the API version is provided as
 
     10000 * major + 100 * minor + patch
 
@@ -49,9 +49,9 @@ def get_api_version() -> str:
     """
     api_version = lib.xtb_getAPIVersion()
     return "{}.{}.{}".format(
-        int(api_version / 10000),
-        int(api_version % 10000 / 100),
-        int(api_version % 100),
+        api_version // 10000,
+        api_version % 10000 // 100,
+        api_version % 100,
     )
 
 

--- a/xtb/test_libxtb.py
+++ b/xtb/test_libxtb.py
@@ -16,10 +16,11 @@
 # along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from pkg_resources import parse_version
 from xtb import API_VERSION
 from xtb.libxtb import get_api_version
 
 
 def test_api_version():
     """Ensure that the API version is compatible."""
-    assert get_api_version() >= API_VERSION
+    assert parse_version(get_api_version()) >= parse_version(API_VERSION)


### PR DESCRIPTION
- use `pkg_resources` for safely comparing version strings
- also use integer division instead to save conversion back to `int`