### PR TITLE
Patch tests for compatibility with xtb 6.4.X

### DIFF
--- a/xtb/qcschema/test_qcschema.py
+++ b/xtb/qcschema/test_qcschema.py
@@ -63,7 +63,7 @@ def test_gfn2xtb_energy():
         }
     )
     dipole_moment = np.array(
-        [0.3345064021648074, -1.0700925215553294, -1.2299195418603437]
+        [0.33451151977076465, -1.0701017905608206, -1.229921234359929]
     )
 
     atomic_result = run_qcschema(atomic_input)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

### Description
With xtb 6.3.3 the tests work fine but with 6.4.1 they failed with the following error message:
```
>       assert approx(atomic_result.properties.scf_dipole_moment, abs=thr) == dipole_moment
E       assert approx([0.33451151977076465 ± 1.0e-07, -1.0701017905608206 ± 1.0e-07, -1.229921234359929 ± 1.0e-07]) == array([ 0.3345064 , -1.07009252, -1.22991954])
E         +approx([0.33451151977076465 ± 1.0e-07, -1.0701017905608206 ± 1.0e-07, -1.229921234359929 ± 1.0e-07])
E         -array([ 0.3345064 , -1.07009252, -1.22991954])

../_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_place/lib/python3.9/site-packages/xtb/qcschema/test_qcschema.py:73: AssertionError
=========================== short test summary info ============================
FAILED qcschema/test_qcschema.py::test_gfn2xtb_energy - assert approx([0.3345...
======================== 1 failed, 29 passed in 10.16s =========================
```
The issue appeared during building the conda package: https://github.com/conda-forge/xtb-python-feedstock/pull/12 

### Changelog description
I updated the tests to included the updated values from xtb 6.4.1. 

### Status
-
