### PR TITLE
Fix unknown option error in meson >= 0.60.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -44,7 +44,6 @@ else
     version: '>=6.3',
     default_options: [
       'default_library=static',
-      #'static=false',
       'openmp=@0@'.format(get_option('openmp')),
       'la_backend=@0@'.format(get_option('la_backend')),
       'optimization=@0@'.format(get_option('optimization')),

--- a/meson.build
+++ b/meson.build
@@ -44,7 +44,7 @@ else
     version: '>=6.3',
     default_options: [
       'default_library=static',
-      'static=false',
+      #'static=false',
       'openmp=@0@'.format(get_option('openmp')),
       'la_backend=@0@'.format(get_option('la_backend')),
       'optimization=@0@'.format(get_option('optimization')),


### PR DESCRIPTION
### Description
Attempting to install xtb-python using meson versions past 0.60.0 produces the following error:

`subprojects/xtb/meson.build:19:0: ERROR: In subproject xtb: Unknown options: "xtb:static"`

Commenting out line 47 in the primary meson.build file suppresses this error. 

I have not looked through the repository in-depth to confirm that this setting is not used, but this error coincides with a change to meson to [always produce a fatal error when an unknown setting is encountered](https://mesonbuild.com/Release-notes-for-0-60-0.html). xTB-python appears to install and run correctly with this setting disabled.

### Changelog description
Fixed unknown option error in meson versions >= 0.60.0
