### PR TITLE
Add support for verbosity keyword

### DIFF
--- a/xtb/interface.py
+++ b/xtb/interface.py
@@ -17,6 +17,7 @@
 """Wrapper around the C-API of the xtb shared library."""
 
 from typing import List, Optional, Union
+from typing_extensions import Literal
 from enum import Enum, auto
 import numpy as np
 
@@ -29,7 +30,16 @@ from .libxtb import (
     new_calculator,
     new_results,
     copy_results,
+    VERBOSITY_FULL,
+    VERBOSITY_MINIMAL,
+    VERBOSITY_MUTED
 )
+
+_verbosity_flags = {
+    "full": VERBOSITY_FULL,
+    "minimal": VERBOSITY_MINIMAL,
+    "muted": VERBOSITY_MUTED
+}
 
 
 class XTBException(Exception):
@@ -216,9 +226,11 @@ class Environment:
         """Release output unit from this environment"""
         _lib.xtb_releaseOutput(self._env)
 
-    def set_verbosity(self, verbosity: int) -> None:
+    def set_verbosity(self, verbosity: Union[Literal["full", "minimal", "muted"], int]) -> int:
         """Set verbosity of calculation output"""
+        verbosity = _verbosity_flags.get(verbosity, verbosity)
         _lib.xtb_setVerbosity(self._env, verbosity)
+        return verbosity
 
 
 class Molecule(Environment):

--- a/xtb/qcschema/harness.py
+++ b/xtb/qcschema/harness.py
@@ -200,7 +200,7 @@ def run_qcschema(
         return_result = 0.0
         properties = {}
 
-    if verbosity > VERBOSITY_MUTED and fd is not None:
+    if fd is not None:
         output = fd.read().decode()
         fd.close()
 

--- a/xtb/qcschema/harness.py
+++ b/xtb/qcschema/harness.py
@@ -119,6 +119,7 @@ def run_qcschema(
         return qcel.models.AtomicResult(**ret_data)
 
     verbosity = atomic_input.keywords.get("verbosity", "full")
+    verbosity = _verbosity_flags.get(verbosity, verbosity)
     output = None
     success = True
     try:
@@ -145,7 +146,6 @@ def run_qcschema(
             )
 
         # Work out how verbose the printing from xtb should be
-        verbosity = _verbosity_flags.get(verbosity, verbosity)
         calc.set_verbosity(verbosity)
         if verbosity > VERBOSITY_MUTED:
             fd = NamedTemporaryFile()

--- a/xtb/qcschema/harness.py
+++ b/xtb/qcschema/harness.py
@@ -145,10 +145,9 @@ def run_qcschema(
             )
 
         # Work out how verbose the printing from xtb should be
-        if isinstance(verbosity, str):
-            verbosity = _verbosity_flags[verbosity.lower()]
+        verbosity = _verbosity_flags.get(verbosity, verbosity)
         calc.set_verbosity(verbosity)
-        if verbosity > 0:
+        if verbosity > VERBOSITY_MUTED:
             fd = NamedTemporaryFile()
             calc.set_output(fd.name)
 
@@ -206,7 +205,7 @@ def run_qcschema(
         return_result = 0.0
         properties = {}
 
-    if verbosity > 0:
+    if verbosity > VERBOSITY_MUTED:
         output = fd.read().decode()
         fd.close()
 

--- a/xtb/qcschema/harness.py
+++ b/xtb/qcschema/harness.py
@@ -36,7 +36,7 @@ Supported keywords are
 
 from typing import Union
 from tempfile import NamedTemporaryFile
-from ..libxtb import VERBOSITY_FULL, VERBOSITY_MINIMAL, VERBOSITY_MUTED, get_api_version
+from ..libxtb import VERBOSITY_MUTED, get_api_version
 from ..interface import Calculator, XTBException
 from ..utils import get_method, get_solvent
 import qcelemental as qcel
@@ -49,11 +49,6 @@ _keywords = [
     "solvent",
     "verbosity"
 ]
-_verbosity_flags = {
-    "full": VERBOSITY_FULL,
-    "minimal": VERBOSITY_MINIMAL,
-    "muted": VERBOSITY_MUTED
-}
 
 
 def run_qcschema(
@@ -119,7 +114,7 @@ def run_qcschema(
         return qcel.models.AtomicResult(**ret_data)
 
     verbosity = atomic_input.keywords.get("verbosity", "full")
-    verbosity = _verbosity_flags.get(verbosity, verbosity)
+    fd = None
     output = None
     success = True
     try:
@@ -146,7 +141,7 @@ def run_qcschema(
             )
 
         # Work out how verbose the printing from xtb should be
-        calc.set_verbosity(verbosity)
+        verbosity = calc.set_verbosity(verbosity)
         if verbosity > VERBOSITY_MUTED:
             fd = NamedTemporaryFile()
             calc.set_output(fd.name)
@@ -205,7 +200,7 @@ def run_qcschema(
         return_result = 0.0
         properties = {}
 
-    if verbosity > VERBOSITY_MUTED:
+    if verbosity > VERBOSITY_MUTED and fd is not None:
         output = fd.read().decode()
         fd.close()
 

--- a/xtb/qcschema/test_qcschema.py
+++ b/xtb/qcschema/test_qcschema.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with xtb.  If not, see <https://www.gnu.org/licenses/>.
-
+import pytest
 from pytest import approx
 from xtb.qcschema.harness import run_qcschema
 import qcelemental as qcel
@@ -447,3 +447,42 @@ def test_gfn1xtb_solvation():
 
     assert atomic_result.success
     assert approx(atomic_result.return_result, abs=thr) == -24.804166790730523
+
+
+@pytest.mark.parametrize("verbosity", [
+    pytest.param("muted", id="muted flag"),
+    pytest.param(0, id="muted value")
+])
+def test_verbosity(verbosity):
+    """Make sure out put is only saved when requested."""
+
+    atomic_input = qcel.models.AtomicInput(
+        molecule={
+            "symbols": [
+                "C", "C", "C", "C", "N", "C", "S", "H", "H", "H", "H", "H",
+            ],
+            "geometry": [
+                -2.56745685564671, -0.02509985979910, 0.00000000000000,
+                -1.39177582455797, 2.27696188880014, 0.00000000000000,
+                1.27784995624894, 2.45107479759386, 0.00000000000000,
+                2.62801937615793, 0.25927727028120, 0.00000000000000,
+                1.41097033661123, -1.99890996077412, 0.00000000000000,
+                -1.17186102298849, -2.34220576284180, 0.00000000000000,
+                -2.39505990368378, -5.22635838332362, 0.00000000000000,
+                2.41961980455457, -3.62158019253045, 0.00000000000000,
+                -2.51744374846065, 3.98181713686746, 0.00000000000000,
+                2.24269048384775, 4.24389473203647, 0.00000000000000,
+                4.66488984573956, 0.17907568006409, 0.00000000000000,
+                -4.60044244782237, -0.17794734637413, 0.00000000000000,
+            ],
+        },
+        driver="energy",
+        model={
+            "method": "GFN1-xTB",
+        },
+        keywords={"verbosity": verbosity}
+    )
+
+    atomic_result = run_qcschema(atomic_input)
+    assert atomic_result.stdout is None  # make sure no output was saved
+    assert atomic_result.return_result is not None  # make sure the calculation was run


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the PR's purpose here. -->
This PR implements and fixes #73 by adding support for a verbosity keyword which when set to muted will stop temporary files from being made which causes a failure when running many parallel xtb calculations. 

### Changelog description
<!-- Provide a brief single sentence for the changelog. -->
The harness now accepts a `verbosity` keyword which can be a string or int corresponding to the level of verbosity, the accepted strings and associated ints are `full=2`, `minimal=1`, `muted=0`.

### Status
<!-- Please, add tests and documentation for your contribution. -->
Ready to go