### PR TITLE
xtb-python: patch meson build file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -46,6 +46,7 @@ python = pymod.find_installation(
   modules: [
     'cffi',
   ],
+  pure: false,
 )
 python_dep = python.dependency(required: true)
 


### PR DESCRIPTION
At least with meson 1.3.2 one has to set pure to false for find installation or else build fails.

<!-- Thank you for your contribution! -->

### Description

Spack build of xtb-python 22.1 using meson 1.3.2 fails
```
==> Installing py-xtb-22.1-cqclpmntnhow4sclhwir2rm5tfzsl4s7 [43/43]
==> No binary for py-xtb-22.1-cqclpmntnhow4sclhwir2rm5tfzsl4s7 found: installing from source
==> Using cached archive: /users/hpritchard/spack/var/spack/cache/_source-cache/archive/7a/7a59e7b783fc6e8b7328f55211de681e535a83991b07c4bab73494063f5e9018.tar.gz
==> No patches needed for py-xtb
==> py-xtb: Executing phase: 'install'
==> Error: ProcessError: Command exited with status 1:
    '/users/hpritchard/spack/opt/spack/linux-almalinux8-thunderx2/gcc-8.5.0/python-venv-1.0-h4dabrwea4h4cdc3oh7okmt276dyd3xs/bin/python3' '-m' 'pip' '-vvv' '--no-input' '--no-cache-dir' '--disable-pip-version-check' 'install' '--no-deps' '--ignore-installed' '--no-build-isolation' '--no-warn-script-location' '--no-index' '--prefix=/users/hpritchard/spack/opt/spack/linux-almalinux8-thunderx2/gcc-8.5.0/py-xtb-22.1-cqclpmntnhow4sclhwir2rm5tfzsl4s7' '.'

2 errors found in build log:
     51    
     52      + /users/hpritchard/spack/opt/spack/linux-almalinux8-thunderx2/gcc-8.5.0/ninja-1.12.0-rxuhvodren5ri3sejoaquxsxwymagsf3/bin/ninja
     53      [1/3] Compiling C object lib_libxtb.a.p/meson-generated_..__libxtb.c.o
     54      [2/3] Linking static target lib_libxtb.a
     55      [3/3] Linking target _libxtb.cpython-311-aarch64-linux-gnu.so
     56    
  >> 57    ('\x1b[31m',)meson-python: error: The xtb package is split between purelib and platlib: 'purelib/xtb/__init__.py' and 'platlib/xtb/_libxtb.cpython-311-aarch64-linux-gnu.so', a "pure: false" argument may be missing in meson.build. It is recommended to se
           t it in "import('python').find_installation()"
     58      error: subprocess-exited-with-error
     59    
     60      × Preparing metadata (pyproject.toml) did not run successfully.
     61      │ exit code: 1
     62      ╰─> See above for output.
     63    
     64      note: This error originates from a subprocess, and is likely not a problem with pip.
     65      full command: /users/hpritchard/spack/opt/spack/linux-almalinux8-thunderx2/gcc-8.5.0/python-venv-1.0-h4dabrwea4h4cdc3oh7okmt276dyd3xs/bin/python3 /users/hpritchard/spack/opt/spack/linux-almalinux8-thunderx2/gcc-8.5.0/py-pip-23.1.2-pty4hpez4jrdt2zznnhd
           pcf72f6uepf6/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py prepare_metadata_for_build_wheel /tmp/tmp0jvh3gl6
     66      cwd: /tmp/hpritchard/spack-stage/spack-stage-py-xtb-22.1-cqclpmntnhow4sclhwir2rm5tfzsl4s7/spack-src
     67      Preparing metadata (pyproject.toml): finished with status 'error'
  >> 68    error: metadata-generation-failed
     69    
     70    × Encountered error while generating package metadata.
     71    ╰─> See above for output.
     72    
     73    note: This is an issue with the package mentioned above, not pip.
     74    hint: See above for details.

```
Opening a PR here as the Spack developers prefer patches pulled from PRs etc as opposed to standalone patches.



### Changelog description
Fix meson.build

### Status
Spack build succeeds with patch based off of this commit.
