### PR TITLE
QCSchema v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,7 @@ jobs:
         create-args: >-
           python=${{ matrix.python }}
           c-compiler fortran-compiler meson-python pytest
+          xtb
           ${{ (matrix.python == '3.14' || matrix.python == '3.13') && 'conda-forge/label/qcelemental_dev::qcelemental>=0.50.0rc3' || 'qcelemental' }}
 
     - name: Setup build of extension module

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v3
@@ -73,7 +73,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     defaults:
       run:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         python -m build . --sdist --outdir . -n ${{ env.SETUP_ARGS }}
       env:
         SETUP_ARGS: >-
-          -Csetup-args=-Dxtb-6.5.1:la_backend=netlib
+          -Csetup-args=-Dxtb-6.7.1:la_backend=netlib
           -Csetup-args=-Dmctc-lib:json=disabled
     - uses: actions/upload-artifact@v4
       with:
@@ -56,7 +56,7 @@ jobs:
         pip3 install . ${{ env.SETUP_ARGS }}
       env:
         SETUP_ARGS: >-
-          --config-settings setup-args=-Dxtb-6.5.1:la_backend=netlib
+          --config-settings setup-args=-Dxtb-6.7.1:la_backend=netlib
 
     - name: Test Python package
       run: pytest -v --pyargs xtb
@@ -111,7 +111,7 @@ jobs:
       env:
         plat: manylinux${{ matrix.python == '3.6' && '2010' || '_2_12' }}_x86_64
         SETUP_ARGS: >-
-          -Csetup-args=-Dxtb-6.5.1:la_backend=netlib
+          -Csetup-args=-Dxtb-6.7.1:la_backend=netlib
           -Csetup-args=-Dmctc-lib:json=disabled
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
           xtb
           qcelemental
     - run: |
+        export PKG_CONFIG_PATH="$CONDA_PREFIX/lib/pkgconfig:$CONDA_PREFIX/share/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
         python -m build . --sdist --outdir . -n ${{ env.SETUP_ARGS }}
       env:
         SETUP_ARGS: >-
@@ -84,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     defaults:
       run:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v4
@@ -124,6 +124,7 @@ jobs:
       env:
         plat: manylinux${{ matrix.python == '3.6' && '2010' || '_2_12' }}_x86_64
         SETUP_ARGS: >-
+          -Csetup-args=-Dpkg_config_path=$CONDA_PREFIX/lib/pkgconfig
           -Csetup-args=-Dxtb-6.7.1:la_backend=netlib
           -Csetup-args=-Dmctc-lib:json=disabled
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,11 +52,22 @@ jobs:
           xtb
           ${{ (matrix.python == '3.14' || matrix.python == '3.13') && 'conda-forge/label/qcelemental_dev::qcelemental>=0.50.0rc3' || 'qcelemental' }}
 
+    - name: Debug xtb discovery
+      run: |
+        echo "CONDA_PREFIX=$CONDA_PREFIX"
+        find "$CONDA_PREFIX" -name 'xtb*.pc' -o -name 'pkgconfig' | sort
+        export PKG_CONFIG_PATH="$CONDA_PREFIX/lib/pkgconfig:$CONDA_PREFIX/share/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+        echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH"
+        pkg-config --list-all | grep -i xtb || true
+        pkg-config --modversion xtb || true
+        pkg-config --cflags --libs xtb || true
+
     - name: Setup build of extension module
       run: |
         pip3 install . ${{ env.SETUP_ARGS }}
       env:
         SETUP_ARGS: >-
+          --config-settings setup-args=-Dpkg_config_path=$CONDA_PREFIX/lib/pkgconfig
           --config-settings setup-args=-Dxtb-6.7.1:la_backend=netlib
 
     - name: Test Python package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,67 +67,100 @@ jobs:
       env:
         OMP_NUM_THREADS: 2,1
 
-  manylinux:
+  wheels:
     needs:
       - sdist
-    runs-on: ubuntu-latest
-    container: condaforge/linux-anvil-cos7-x86_64
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - macos-15-intel
+        python: ["38", "39", "310", "311", "312", "313", "314"]
+        include:
+          - os: ubuntu-latest
+            archs_linux: x86_64
+          - os: macos-latest
+            archs_macos: arm64
+          - os: macos-15-intel
+            archs_macos: x86_64
 
     defaults:
       run:
-        shell: ${{ matrix.shell || 'bash -l {0}' }}
+        shell: bash -l {0}
 
     steps:
-    - name: Create environment
-      run: >-
-        mamba create -n wheel
-        --yes
-        c-compiler
-        fortran-compiler
-        python=${{ matrix.python }}
-        auditwheel
-        git
-        python-build
-        pkg-config
-        patchelf
-        cffi
-        numpy
-        meson
-        unzip
-        wheel
-        xtb
-    - name: Download sdist
-      uses: actions/download-artifact@v8
-      with:
-        name: xtb-python-sdist
-    - name: Build wheel
-      run: |
-        conda activate wheel
-        set -ex
-        tar xvf xtb-*.tar.gz
-        python -m build xtb-*/ --wheel ${{ env.SETUP_ARGS }}
-        auditwheel show xtb-*/dist/*.whl
-        auditwheel repair -w . xtb-*/dist/*.whl --plat ${{ env.plat }}
-      env:
-        plat: manylinux${{ matrix.python == '3.6' && '2010' || '_2_12' }}_x86_64
-        SETUP_ARGS: >-
-          -Csetup-args=-Dpkg_config_path=$CONDA_PREFIX/lib/pkgconfig
-          -Csetup-args=-Dxtb-6.7.1:la_backend=netlib
-          -Csetup-args=-Dmctc-lib:json=disabled
-    - uses: actions/upload-artifact@v7
-      with:
-        name: xtb-python-${{ matrix.python }}
-        path: ./*.whl
-        retention-days: 5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Install cibuildwheel
+        run: python -m pip install "cibuildwheel>=3"
+
+      - name: Download sdist
+        uses: actions/download-artifact@v8
+        with:
+          name: xtb-python-sdist
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir . *.tar.gz
+        env:
+          CIBW_BUILD: "cp${{ matrix.python }}-*"
+          CIBW_BUILD_VERBOSITY: 1
+          CIBW_SKIP: "*musllinux*"
+          CIBW_ARCHS_LINUX: ${{ matrix.archs_linux || '' }}
+          CIBW_ARCHS_MACOS: ${{ matrix.archs_macos || '' }}
+
+          # Linux setup inside the manylinux container
+          CIBW_BEFORE_ALL_LINUX: >
+            yum install -y pkgconfig &&
+            curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest |
+            tar -xvj bin/micromamba &&
+            ./bin/micromamba create -y -p /opt/conda-env
+            -c conda-forge
+            python
+            cffi
+            numpy
+            meson
+            ninja
+            pkg-config
+            xtb
+
+          # Pass host env vars through when needed
+          CIBW_ENVIRONMENT_PASS_LINUX: PKG_CONFIG_PATH
+
+          # Configure the build inside the Linux wheel container
+          CIBW_ENVIRONMENT_LINUX: >
+            PATH="/opt/conda-env/bin:$PATH"
+            PKG_CONFIG_PATH="/opt/conda-env/lib/pkgconfig:/opt/conda-env/share/pkgconfig"
+            XTBPATH="/opt/conda-env/share/xtb"
+            PIP_CONFIG_SETTINGS="setup-args=-Dpkg_config_path=/opt/conda-env/lib/pkgconfig setup-args=-Dxtb-6.7.1:la_backend=netlib setup-args=-Dmctc-lib:json=disabled"
+
+          # If xtb links shared libraries that need bundling, keep auditwheel repair enabled.
+          # If the package ends up fully self-contained / static, the default repair is still fine.
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel}"
+
+          # macOS setup
+          CIBW_BEFORE_ALL_MACOS: |
+            brew install meson ninja pkg-config xtb
+
+          CIBW_ENVIRONMENT_MACOS: >
+            PKG_CONFIG_PATH="$(brew --prefix xtb)/lib/pkgconfig:$(brew --prefix xtb)/share/pkgconfig"
+            XTBPATH="$(brew --prefix xtb)/share/xtb"
+            PIP_CONFIG_SETTINGS="setup-args=-Dpkg_config_path=$(brew --prefix xtb)/lib/pkgconfig setup-args=-Dxtb-6.7.1:la_backend=netlib setup-args=-Dmctc-lib:json=disabled"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: xtb-python-${{ matrix.os }}-${{ matrix.python }}
+          path: ./*.whl
+          retention-days: 5
 
   release:
     needs:
       - sdist
-      - manylinux
+      - wheels
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,6 +113,13 @@ jobs:
           CIBW_ARCHS_LINUX: ${{ matrix.archs_linux || '' }}
           CIBW_ARCHS_MACOS: ${{ matrix.archs_macos || '' }}
 
+          CIBW_BEFORE_BUILD_LINUX: >
+            which python &&
+            python -V &&
+            echo "$PATH" &&
+            pkg-config --modversion xtb &&
+            pkg-config --cflags --libs xtb
+
           # Linux setup inside the manylinux container
           CIBW_BEFORE_ALL_LINUX: >
             yum install -y pkgconfig &&
@@ -133,9 +140,9 @@ jobs:
 
           # Configure the build inside the Linux wheel container
           CIBW_ENVIRONMENT_LINUX: >
-            PATH="/opt/conda-env/bin:$PATH"
             PKG_CONFIG_PATH="/opt/conda-env/lib/pkgconfig:/opt/conda-env/share/pkgconfig"
             XTBPATH="/opt/conda-env/share/xtb"
+            LD_LIBRARY_PATH="/opt/conda-env/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
             PIP_CONFIG_SETTINGS="setup-args=-Dpkg_config_path=/opt/conda-env/lib/pkgconfig setup-args=-Dxtb-6.7.1:la_backend=netlib setup-args=-Dmctc-lib:json=disabled"
 
           # If xtb links shared libraries that need bundling, keep auditwheel repair enabled.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup Python
       uses: mamba-org/provision-with-micromamba@main
       with:
@@ -23,7 +23,7 @@ jobs:
         SETUP_ARGS: >-
           -Csetup-args=-Dxtb-6.5.1:la_backend=netlib
           -Csetup-args=-Dmctc-lib:json=disabled
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: xtb-python-sdist
         path: ./*.tar.gz
@@ -40,7 +40,7 @@ jobs:
         python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup Python
       uses: mamba-org/provision-with-micromamba@main
@@ -99,7 +99,7 @@ jobs:
         wheel
         xtb
     - name: Download sdist
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: xtb-python-sdist
     - name: Build wheel
@@ -115,7 +115,7 @@ jobs:
         SETUP_ARGS: >-
           -Csetup-args=-Dxtb-6.5.1:la_backend=netlib
           -Csetup-args=-Dmctc-lib:json=disabled
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: xtb-python-${{ matrix.python }}
         path: ./*.whl
@@ -128,7 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           path: ${{ github.workspace }}  # This will download all files
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,12 +11,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup Python
-      uses: mamba-org/provision-with-micromamba@main
+      uses: mamba-org/setup-micromamba@v1
       with:
         environment-file: environment.yml
-        extra-specs: |
-          meson-python
-          python-build
+        create-args: >-
+          meson-python python-build
+          qcelemental
     - run: |
         python -m build . --sdist --outdir . -n ${{ env.SETUP_ARGS }}
       env:
@@ -43,15 +43,13 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Setup Python
-      uses: mamba-org/provision-with-micromamba@main
+      uses: mamba-org/setup-micromamba@v1
       with:
         environment-file: environment.yml
-        extra-specs: |
-          c-compiler
-          fortran-compiler
-          meson-python
+        create-args: >-
           python=${{ matrix.python }}
-          pytest
+          c-compiler fortran-compiler meson-python pytest
+          ${{ (matrix.python == '3.14' || matrix.python == '3.13') && 'conda-forge/label/qcelemental_dev::qcelemental>=0.50.0rc3' || 'qcelemental' }}
 
     - name: Setup build of extension module
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
         environment-file: environment.yml
         create-args: >-
           meson-python python-build
+          xtb
           qcelemental
     - run: |
         python -m build . --sdist --outdir . -n ${{ env.SETUP_ARGS }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup Python
-      uses: mamba-org/setup-micromamba@v1
+      uses: mamba-org/setup-micromamba@v3
       with:
         environment-file: environment.yml
         create-args: >-
@@ -25,7 +25,7 @@ jobs:
         SETUP_ARGS: >-
           -Csetup-args=-Dxtb-6.7.1:la_backend=netlib
           -Csetup-args=-Dmctc-lib:json=disabled
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: xtb-python-sdist
         path: ./*.tar.gz
@@ -45,7 +45,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Setup Python
-      uses: mamba-org/setup-micromamba@v1
+      uses: mamba-org/setup-micromamba@v3
       with:
         environment-file: environment.yml
         create-args: >-
@@ -53,16 +53,6 @@ jobs:
           c-compiler fortran-compiler meson-python pytest
           xtb
           ${{ (matrix.python == '3.14' || matrix.python == '3.13') && 'conda-forge/label/qcelemental_dev::qcelemental>=0.50.0rc3' || 'qcelemental' }}
-
-    - name: Debug xtb discovery
-      run: |
-        echo "CONDA_PREFIX=$CONDA_PREFIX"
-        find "$CONDA_PREFIX" -name 'xtb*.pc' -o -name 'pkgconfig' | sort
-        export PKG_CONFIG_PATH="$CONDA_PREFIX/lib/pkgconfig:$CONDA_PREFIX/share/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
-        echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH"
-        pkg-config --list-all | grep -i xtb || true
-        pkg-config --modversion xtb || true
-        pkg-config --cflags --libs xtb || true
 
     - name: Setup build of extension module
       run: |
@@ -111,7 +101,7 @@ jobs:
         wheel
         xtb
     - name: Download sdist
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: xtb-python-sdist
     - name: Build wheel
@@ -128,7 +118,7 @@ jobs:
           -Csetup-args=-Dpkg_config_path=$CONDA_PREFIX/lib/pkgconfig
           -Csetup-args=-Dxtb-6.7.1:la_backend=netlib
           -Csetup-args=-Dmctc-lib:json=disabled
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: xtb-python-${{ matrix.python }}
         path: ./*.whl
@@ -141,7 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ${{ github.workspace }}  # This will download all files
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,16 +76,10 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
-          - macos-15-intel
         python: ["38", "39", "310", "311", "312", "313", "314"]
         include:
           - os: ubuntu-latest
             archs_linux: x86_64
-          - os: macos-latest
-            archs_macos: arm64
-          - os: macos-15-intel
-            archs_macos: x86_64
 
     defaults:
       run:
@@ -111,7 +105,6 @@ jobs:
           CIBW_BUILD_VERBOSITY: 1
           CIBW_SKIP: "*musllinux*"
           CIBW_ARCHS_LINUX: ${{ matrix.archs_linux || '' }}
-          CIBW_ARCHS_MACOS: ${{ matrix.archs_macos || '' }}
 
           CIBW_BEFORE_BUILD_LINUX: >
             which python &&
@@ -148,15 +141,6 @@ jobs:
           # If xtb links shared libraries that need bundling, keep auditwheel repair enabled.
           # If the package ends up fully self-contained / static, the default repair is still fine.
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel}"
-
-          # macOS setup
-          CIBW_BEFORE_ALL_MACOS: |
-            brew install meson ninja pkg-config xtb
-
-          CIBW_ENVIRONMENT_MACOS: >
-            PKG_CONFIG_PATH="$(brew --prefix xtb)/lib/pkgconfig:$(brew --prefix xtb)/share/pkgconfig"
-            XTBPATH="$(brew --prefix xtb)/share/xtb"
-            PIP_CONFIG_SETTINGS="setup-args=-Dpkg_config_path=$(brew --prefix xtb)/lib/pkgconfig setup-args=-Dxtb-6.7.1:la_backend=netlib setup-args=-Dmctc-lib:json=disabled"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/python-linter.yml
+++ b/.github/workflows/python-linter.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:

--- a/environment.yml
+++ b/environment.yml
@@ -5,4 +5,4 @@ dependencies:
   - ase
   - cffi
   - numpy
-  - qcelemental
+  # - qcelemental  # added with logic in GHA

--- a/environment.yml
+++ b/environment.yml
@@ -5,4 +5,5 @@ dependencies:
   - ase
   - cffi
   - numpy
+  - setuptools
   # - qcelemental  # added with logic in GHA

--- a/meson.build
+++ b/meson.build
@@ -29,7 +29,7 @@ install = true
 xtb_dep = dependency(
   'xtb',
   version: '>=@0@'.format(meson.project_version()),
-  fallback: ['xtb-6.5.1', 'xtb_dep'],
+  fallback: ['xtb-6.7.1', 'xtb_dep'],
   default_options: [
     'default_library=static',
     'c_api=true',

--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,7 @@
 project(
   'xtb-python',
   'c',
+  version: '26.1',
   license: 'LGPL-3.0-or-later',
   default_options: [
     'default_library=static',

--- a/meson.build
+++ b/meson.build
@@ -28,7 +28,6 @@ install = true
 
 xtb_dep = dependency(
   'xtb',
-  version: '>=@0@'.format(meson.project_version()),
   fallback: ['xtb-6.7.1', 'xtb_dep'],
   default_options: [
     'default_library=static',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["meson-python", "cffi"]
+requires = ["meson-python", "cffi", "setuptools"]
 build-backend = "mesonpy"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,16 +14,17 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "Programming Language :: Fortran",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.6",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Scientific/Engineering :: Chemistry",
   "Topic :: Scientific/Engineering :: Physics",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
    "cffi",
    "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,4 +35,5 @@ optional-dependencies.test = [
   "pytest-cov",
   "ase",
   "qcelemental",
+  "setuptools",
 ]

--- a/subprojects/xtb-6.7.1.wrap
+++ b/subprojects/xtb-6.7.1.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = xtb-6.7.1
+
+source_url =  https://github.com/grimme-lab/xtb/releases/download/v6.7.1/xtb-6.7.1-source.tar.xz
+source_filename = xtb-6.7.1-source.tar.xz
+source_hash = 79a2a2f50091b3b941e5139c1b38a53203d5d2e9ba496a7ad505d8c31ccd6013

--- a/xtb/ase/__init__.py
+++ b/xtb/ase/__init__.py
@@ -14,8 +14,3 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with xtb.  If not, see <https://www.gnu.org/licenses/>.
-
-try:
-    import ase
-except ModuleNotFoundError:
-    raise ModuleNotFoundError("This submodule requires ASE installed")

--- a/xtb/ase/calculator.py
+++ b/xtb/ase/calculator.py
@@ -60,9 +60,13 @@ from typing import List, Optional
 from ..utils import get_method, get_solvent
 from ..libxtb import VERBOSITY_MUTED
 from ..interface import Calculator, XTBException
-import ase.calculators.calculator as ase_calc
-from ase.atoms import Atoms
-from ase.units import Hartree, Bohr
+
+try:
+    import ase.calculators.calculator as ase_calc
+    from ase.atoms import Atoms
+    from ase.units import Hartree, Bohr
+except ModuleNotFoundError:
+    raise ModuleNotFoundError("This submodule requires ASE installed")
 
 
 class XTB(ase_calc.Calculator):

--- a/xtb/ase/test_calculator.py
+++ b/xtb/ase/test_calculator.py
@@ -22,13 +22,18 @@
     energies in eV (while xtb is working internally in atomic units).
 """
 
-from xtb.ase.calculator import XTB
-from ase.atoms import Atoms
-from ase.calculators.calculator import CalculationFailed, InputError
-from pytest import approx, raises
+from pytest import approx, raises, mark
 import numpy as np
 
+try:
+    from xtb.ase.calculator import XTB
+    from ase.atoms import Atoms
+    from ase.calculators.calculator import CalculationFailed, InputError
+except ModuleNotFoundError:
+    ase = None
 
+
+@mark.skipif(ase is None, reason="requires ase")
 def test_gfn2_xtb_0d():
     """Test ASE interface to GFN2-xTB"""
     thr = 1.0e-5
@@ -97,6 +102,7 @@ def test_gfn2_xtb_0d():
     assert approx(atoms.get_potential_energy(), abs=thr) == -592.9940608761889
 
 
+@mark.skipif(ase is None, reason="requires ase")
 def test_gfn1_xtb_0d():
     """Test ASE interface to GFN1-xTB"""
     thr = 1.0e-5
@@ -156,6 +162,7 @@ def test_gfn1_xtb_0d():
     assert approx(atoms.get_dipole_moment(), abs=thr) == dipole_moment
 
 
+@mark.skipif(ase is None, reason="requires ase")
 def test_gfn1_xtb_3d():
     """Test ASE interface to GFN1-xTB"""
     thr = 5.0e-6
@@ -207,6 +214,7 @@ def test_gfn1_xtb_3d():
     assert approx(atoms.get_charges(), abs=thr) == charges
 
 
+@mark.skipif(ase is None, reason="requires ase")
 def test_gfn2_xtb_3d():
     """Test ASE interface to GFN2-xTB, should fail"""
     thr = 5.0e-6
@@ -246,6 +254,7 @@ def test_gfn2_xtb_3d():
         calc.calculate(atoms=atoms, system_changes=["positions"])
 
 
+@mark.skipif(ase is None, reason="requires ase")
 def test_invalid_method():
     """GFN-xTB without method number is invalid, should raise an input error"""
 

--- a/xtb/ase/test_calculator.py
+++ b/xtb/ase/test_calculator.py
@@ -26,6 +26,7 @@ from pytest import approx, raises, mark
 import numpy as np
 
 try:
+    import ase
     from xtb.ase.calculator import XTB
     from ase.atoms import Atoms
     from ase.calculators.calculator import CalculationFailed, InputError

--- a/xtb/ase/test_optimize.py
+++ b/xtb/ase/test_optimize.py
@@ -20,6 +20,7 @@ from pytest import approx, mark
 import numpy as np
 
 try:
+    import ase
     from xtb.ase.calculator import XTB
     from ase.atoms import Atoms
     from ase.optimize.bfgs import BFGS

--- a/xtb/ase/test_optimize.py
+++ b/xtb/ase/test_optimize.py
@@ -68,8 +68,8 @@ def test_gfn1xtb_bfgs():
     opt = BFGS(atoms)
     opt.run(fmax=0.1)
 
-    assert approx(atoms.get_potential_energy(), thr) == -951.9006674709672
-    assert approx(np.linalg.norm(atoms.get_forces(), ord=2), thr) == 0.2052117803208497
+    assert approx(atoms.get_potential_energy(), abs=thr) == -951.9006674709672
+    assert approx(np.linalg.norm(atoms.get_forces(), ord=2), abs=thr) == 0.2052117803208497
 
 
 @mark.skipif(ase is None, reason="requires ase")
@@ -110,8 +110,8 @@ def test_gfn2xtb_lbfgs():
     opt = LBFGS(atoms)
     opt.run(fmax=0.1)
 
-    assert approx(atoms.get_potential_energy(), thr) == -897.4533662470938
-    assert approx(np.linalg.norm(atoms.get_forces(), ord=2), thr) == 0.19359647527783497
+    assert approx(atoms.get_potential_energy(), abs=thr) == -897.4533662470938
+    assert approx(np.linalg.norm(atoms.get_forces(), ord=2), abs=thr) == 0.19359647527783497
 
 
 @mark.skipif(ase is None, reason="requires ase")
@@ -153,11 +153,11 @@ def test_gfn2xtb_velocityverlet():
     dyn = VelocityVerlet(atoms, timestep=1.0*fs)
     dyn.run(20)
 
-    assert approx(atoms.get_potential_energy(), thr) == -896.9772346260584
-    assert approx(atoms.get_kinetic_energy(), thr) == 0.022411127028842362
+    assert approx(atoms.get_potential_energy(), abs=thr) == -896.9772346260584
+    assert approx(atoms.get_kinetic_energy(), abs=thr) == 0.022411127028842362
 
     atoms.calc.set(cache_api=True)
     dyn.run(20)
 
-    assert approx(atoms.get_potential_energy(), thr) == -896.9913862530841
-    assert approx(atoms.get_kinetic_energy(), thr) == 0.036580471363852810
+    assert approx(atoms.get_potential_energy(), abs=thr) == -896.9913862530841
+    assert approx(atoms.get_kinetic_energy(), abs=thr) == 0.036580471363852810

--- a/xtb/ase/test_optimize.py
+++ b/xtb/ase/test_optimize.py
@@ -35,7 +35,7 @@ except ModuleNotFoundError:
 def test_gfn1xtb_bfgs():
     """Perform geometry optimization with GFN1-xTB and BFGS"""
 
-    thr = 1.0e-5
+    thr = 1.0e-4
 
     atoms = Atoms(
         symbols = "NHCHC2H3OC2H3ONHCH3",

--- a/xtb/ase/test_optimize.py
+++ b/xtb/ase/test_optimize.py
@@ -16,16 +16,21 @@
 # along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 """Tests for some higher level functionality of ASE using the xtb Calculator"""
 
-from xtb.ase.calculator import XTB
-from ase.atoms import Atoms
-from ase.optimize.bfgs import BFGS
-from ase.optimize.lbfgs import LBFGS
-from ase.md.verlet import VelocityVerlet
-from ase.units import fs
-from pytest import approx
+from pytest import approx, mark
 import numpy as np
 
+try:
+    from xtb.ase.calculator import XTB
+    from ase.atoms import Atoms
+    from ase.optimize.bfgs import BFGS
+    from ase.optimize.lbfgs import LBFGS
+    from ase.md.verlet import VelocityVerlet
+    from ase.units import fs
+except ModuleNotFoundError:
+    ase = None
 
+
+@mark.skipif(ase is None, reason="requires ase")
 def test_gfn1xtb_bfgs():
     """Perform geometry optimization with GFN1-xTB and BFGS"""
 
@@ -67,6 +72,7 @@ def test_gfn1xtb_bfgs():
     assert approx(np.linalg.norm(atoms.get_forces(), ord=2), thr) == 0.2052117803208497
 
 
+@mark.skipif(ase is None, reason="requires ase")
 def test_gfn2xtb_lbfgs():
     """Perform geometry optimization with GFN2-xTB and L-BFGS"""
 
@@ -108,6 +114,7 @@ def test_gfn2xtb_lbfgs():
     assert approx(np.linalg.norm(atoms.get_forces(), ord=2), thr) == 0.19359647527783497
 
 
+@mark.skipif(ase is None, reason="requires ase")
 def test_gfn2xtb_velocityverlet():
     """Perform molecular dynamics with GFN2-xTB and Velocity Verlet Integrator"""
 

--- a/xtb/qcschema/__init__.py
+++ b/xtb/qcschema/__init__.py
@@ -14,8 +14,3 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with xtb.  If not, see <https://www.gnu.org/licenses/>.
-
-try:
-    import qcelemental
-except ModuleNotFoundError:
-    raise ModuleNotFoundError("This submodule requires QCElemental installed")

--- a/xtb/qcschema/harness.py
+++ b/xtb/qcschema/harness.py
@@ -20,6 +20,12 @@ This module provides a way to translate QCSchema or QCElemental Atomic Input
 into a format understandable by the ``xtb`` API which in turn provides the
 calculation results in a QCSchema compatible format.
 
+If the QCElemental package is installed the ``xtb.qcschema.harness`` module becomes
+importable and provides the ``run_qcschema`` function supporting QCSchema v1.
+If the QCElemental package is >=0.50.0, ``xtb.qcschema.harness`` supports QCSchema v1
+and v2, returning whichever version was submitted. Note that Python 3.14+ only
+works with QCSchema v2 due to Pydantic restrictions.
+
 The ``xtb`` model supports any method accepted by ``xtb.utils.get_method``.
 
 Supported keywords are

--- a/xtb/qcschema/harness.py
+++ b/xtb/qcschema/harness.py
@@ -35,12 +35,11 @@ Supported keywords are
 """
 
 import sys
-from typing import Union
+from typing import Any, Dict, overload, Union
 from tempfile import NamedTemporaryFile
 from ..libxtb import VERBOSITY_MUTED, get_api_version
 from ..interface import Calculator, XTBException
 from ..utils import get_method, get_solvent
-import qcelemental as qcel
 
 if sys.version_info < (3, 14):
     try:
@@ -54,7 +53,6 @@ try:
     import qcelemental.models.v2 as qcel_v2
 except ModuleNotFoundError:
     qcel_v2 = None
-qcel_v2 = None
 
 
 if qcel_v1 is None and qcel_v2 is None:
@@ -72,10 +70,21 @@ _keywords = [
 ]
 
 
-def run_qcschema(
-    input_data: Union[dict, qcel.models.AtomicInput]
-) -> qcel.models.AtomicResult:
-    """Perform a calculation based on an atomic input model.
+if qcel_v1 is not None:
+    @overload
+    def run_qcschema(
+        input_data: Union[Dict[str, Any], "qcel_v1.AtomicInput"],
+    ) -> Union["qcel_v1.AtomicResult", "qcel_v1.FailedOperation"]: ...
+
+if qcel_v2 is not None:
+    @overload
+    def run_qcschema(
+        input_data: Union[Dict[str, Any], "qcel_v2.AtomicInput"],
+    ) -> Union["qcel_v2.AtomicResult", "qcel_v2.FailedOperation"]: ...
+
+
+def run_qcschema(input_data):
+    """Perform a calculation based on a v1 or v2 QCSchema atomic input model.
 
     Example
     -------
@@ -105,11 +114,38 @@ def run_qcschema(
     -5.070451354848316
     """
 
-    if not isinstance(input_data, qcel.models.AtomicInput):
-        atomic_input = qcel.models.AtomicInput(**input_data)
-    else:
+    if qcel_v2 is not None and isinstance(input_data, qcel_v2.AtomicInput):
         atomic_input = input_data
-    ret_data = atomic_input.dict()
+    elif qcel_v1 is not None and isinstance(input_data, qcel_v1.AtomicInput):
+        atomic_input = input_data
+    elif qcel_v2 is not None and input_data.get("specification"):
+        atomic_input = qcel_v2.AtomicInput(**input_data)
+    elif qcel_v1 is not None:
+        atomic_input = qcel_v1.AtomicInput(**input_data)
+    else:
+        raise ValueError(
+            "Input data is not a valid QCSchema AtomicInput for either v1 or v2."
+        )
+
+    schema_version = atomic_input.schema_version
+    if schema_version == 1:
+        ret_data = atomic_input.dict()
+        input_keywords = atomic_input.keywords
+        input_method = atomic_input.model.method
+        input_driver = atomic_input.driver
+    elif schema_version == 2:
+        ret_data = {
+            "input_data": atomic_input,
+            "extras": {},
+            "molecule": atomic_input.molecule,
+        }
+        input_keywords = atomic_input.specification.keywords
+        input_method = atomic_input.specification.model.method
+        input_driver = atomic_input.specification.driver
+    else:
+        raise ValueError(
+            f"Unsupported QCSchema version: {schema_version}. Only v1 and v2 are supported."
+        )
 
     provenance = {
         "creator": "xtb",
@@ -117,24 +153,29 @@ def run_qcschema(
         "routine": "xtb.qcschema.run_qcschema",
     }
 
-    _method = get_method(atomic_input.model.method)
+    _method = get_method(input_method)
     if _method is None:
-        ret_data.update(
-            success=False,
-            return_result=0.0,
-            provenance=provenance,
-            properties={},
-            error=qcel.models.ComputeError(
-                error_type="input_error",
-                error_message="Invalid method {} provided in model".format(
-                    atomic_input.model.method
-                ),
+        error = dict(
+            error_type="input_error",
+            error_message="Invalid method {} provided in model".format(
+                input_method
             ),
         )
+        if schema_version == 1:
+            ret_data.update(
+                success=False,
+                return_result=0.0,
+                provenance=provenance,
+                properties={},
+                error=error,
+            )
+            return qcel_v1.AtomicResult(**ret_data)
+        elif schema_version == 2:
+            return qcel_v2.FailedOperation(
+                input_data=atomic_input, error=qcel_v2.ComputeError(**error)
+            )
 
-        return qcel.models.AtomicResult(**ret_data)
-
-    verbosity = atomic_input.keywords.get("verbosity", "full")
+    verbosity = input_keywords.get("verbosity", "full")
     fd = None
     output = None
     success = True
@@ -147,18 +188,18 @@ def run_qcschema(
             atomic_input.molecule.molecular_multiplicity - 1,
         )
 
-        if "solvent" in atomic_input.keywords:
-            calc.set_solvent(get_solvent(atomic_input.keywords["solvent"]))
+        if "solvent" in input_keywords:
+            calc.set_solvent(get_solvent(input_keywords["solvent"]))
 
-        if "accuracy" in atomic_input.keywords:
-            calc.set_accuracy(atomic_input.keywords["accuracy"])
+        if "accuracy" in input_keywords:
+            calc.set_accuracy(input_keywords["accuracy"])
 
-        if "max_iterations" in atomic_input.keywords:
-            calc.set_max_iterations(atomic_input.keywords["max_iterations"])
+        if "max_iterations" in input_keywords:
+            calc.set_max_iterations(input_keywords["max_iterations"])
 
-        if "electronic_temperature" in atomic_input.keywords:
+        if "electronic_temperature" in input_keywords:
             calc.set_electronic_temperature(
-                atomic_input.keywords["electronic_temperature"]
+                input_keywords["electronic_temperature"]
             )
 
         # Work out how verbose the printing from xtb should be
@@ -186,11 +227,11 @@ def run_qcschema(
             extras["xtb"]["mulliken_charges"] = res.get_charges()
             extras["xtb"]["mayer_indices"] = res.get_bond_orders()
 
-        if atomic_input.driver == "energy":
+        if input_driver == "energy":
             return_result = properties["return_energy"]
-        elif atomic_input.driver == "gradient":
+        elif input_driver == "gradient":
             return_result = extras["xtb"]["return_gradient"]
-        elif atomic_input.driver == "properties":
+        elif input_driver == "properties":
             return_result = {
                 "dipole": properties["scf_dipole_moment"],
             }
@@ -202,7 +243,7 @@ def run_qcschema(
             success = False
 
             ret_data.update(
-                error=qcel.models.ComputeError(
+                error=dict(
                     error_type="input_error",
                     error_message="Calculation succeeded but invalid driver request provided",
                 ),
@@ -214,9 +255,7 @@ def run_qcschema(
         success = False
 
         ret_data.update(
-            error=qcel.models.ComputeError(
-                error_type="runtime_error", error_message=str(ee),
-            ),
+            error=dict(error_type="runtime_error", error_message=str(ee)),
         )
         return_result = 0.0
         properties = {}
@@ -232,4 +271,11 @@ def run_qcschema(
         return_result=return_result,
     )
 
-    return qcel.models.AtomicResult(**ret_data, stdout=output)
+    if schema_version == 1:
+        return qcel_v1.AtomicResult(**ret_data)
+
+    if "error" in ret_data:
+        return qcel_v2.FailedOperation(
+            input_data=atomic_input, error=ret_data["error"]
+        )
+    return qcel_v2.AtomicResult(**ret_data)

--- a/xtb/qcschema/harness.py
+++ b/xtb/qcschema/harness.py
@@ -34,6 +34,7 @@ Supported keywords are
 ======================== =========== ============================================
 """
 
+import sys
 from typing import Union
 from tempfile import NamedTemporaryFile
 from ..libxtb import VERBOSITY_MUTED, get_api_version
@@ -41,6 +42,26 @@ from ..interface import Calculator, XTBException
 from ..utils import get_method, get_solvent
 import qcelemental as qcel
 
+if sys.version_info < (3, 14):
+    try:
+        import qcelemental.models.v1 as qcel_v1
+    except ModuleNotFoundError:
+        import qcelemental.models as qcel_v1
+else:
+    qcel_v1 = None
+
+try:
+    import qcelemental.models.v2 as qcel_v2
+except ModuleNotFoundError:
+    qcel_v2 = None
+qcel_v2 = None
+
+
+if qcel_v1 is None and qcel_v2 is None:
+    raise ModuleNotFoundError(
+        "The qcelemental package is required for qcschema support. "
+        "Please install it with 'pip install qcelemental'."
+    )
 
 _keywords = [
     "accuracy",

--- a/xtb/qcschema/test_qcschema.py
+++ b/xtb/qcschema/test_qcschema.py
@@ -1,3 +1,19 @@
+# This file is part of xtb.
+#
+# Copyright (C) 2020 Sebastian Ehlert
+#
+# xtb is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# xtb is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 from typing import Any, Dict, Optional
 
 import numpy as np

--- a/xtb/qcschema/test_qcschema.py
+++ b/xtb/qcschema/test_qcschema.py
@@ -247,8 +247,8 @@ def get_atomic_input(
                     "method": method,
                 },
                 "keywords": keywords,
+                "extras": extras,
             },
-            "extras": extras,
         }
         if qcel_object:
             return qcel_v2.AtomicInput(**input_data)
@@ -333,7 +333,10 @@ def test_gfn1xtb_gradient(qcsk_version: int):
     assert approx(atomic_result.properties.return_energy, abs=thr) == -33.63768565903155
     assert approx(atomic_result.properties.scf_dipole_moment, abs=thr) == dipole_moment
     assert approx(atomic_result.return_result, abs=thr) == gradient
-    assert atomic_result.extras["important"] == entry
+    if qcsk_version == 1:
+        assert atomic_result.extras["important"] == entry
+    elif qcsk_version == 2:
+        assert atomic_result.input_data.specification.extras["important"] == entry
 
 
 def test_gfn2xtb_gradient(qcsk_version: int):

--- a/xtb/qcschema/test_qcschema.py
+++ b/xtb/qcschema/test_qcschema.py
@@ -1,31 +1,27 @@
-# This file is part of xtb.
-#
-# Copyright (C) 2020 Sebastian Ehlert
-#
-# xtb is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# xtb is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with xtb.  If not, see <https://www.gnu.org/licenses/>.
+from typing import Any, Dict, Optional
+
+import numpy as np
 import pytest
 from pytest import approx
-from xtb.qcschema.harness import run_qcschema
-import qcelemental as qcel
-import numpy as np
 
-def test_gfn2xtb_energy():
-    """Use QCSchema to calculate the energy of a halogen bond compound"""
-    thr = 1.0e-7
+try:
+    from xtb.qcschema.harness import run_qcschema, qcel_v1, qcel_v2
+except ModuleNotFoundError:
+    qcel_v1 = None
+    qcel_v2 = None
 
-    atomic_input = qcel.models.AtomicInput(
-        molecule = {
+
+v1_available = pytest.mark.skipif(
+    qcel_v1 is None, reason="QCSchema v1 not available for py314+"
+)
+v2_available = pytest.mark.skipif(
+    qcel_v2 is None, reason="QCSchema v2 not available in current QCElemental"
+)
+
+
+def get_molecule(name: str) -> Dict[str, Any]:
+    if name == "halogen_bond":
+        return {
             "symbols": [
                 "C", "C", "C", "C", "C", "C", "I", "H", "H",
                 "H", "H", "H", "S", "H", "C", "H", "H", "H",
@@ -50,35 +46,10 @@ def test_gfn2xtb_energy():
                 -5.07177399637298, 10.99164969235585, -2.10739192258756,
                 -6.35955320518616, 14.08073002965080, -1.68204314084441,
             ],
-        },
-        driver = "energy",
-        model = {
-            "method": "GFN2-xTB",
-        },
-        keywords = {
-            "accuracy": 1.0,
-            "electronic_temperature": 300.0,
-            "max_iterations": 50,
-            "solvent": "none",
         }
-    )
-    dipole_moment = np.array(
-        [0.3345115197707647, -1.0701017905608206, -1.2299212343599290]
-    )
 
-    atomic_result = run_qcschema(atomic_input)
-
-    assert atomic_result.success
-    assert approx(atomic_result.return_result, abs=thr) == -26.60185037124828
-    assert approx(atomic_result.properties.scf_dipole_moment, abs=thr) == dipole_moment
-
-
-def test_gfn1xtb_gradient():
-    """Use QCSchema to perform a GFN1-xTB calculation on a mindless molecule"""
-    thr = 1.0e-7
-
-    atomic_input = {
-        "molecule": {
+    if name == "mindless_gfn1":
+        return {
             "symbols": [
                 "H", "H", "C", "B", "H", "P", "O", "Cl",
                 "Al", "P", "B", "H", "F", "P", "H", "P",
@@ -101,54 +72,10 @@ def test_gfn1xtb_gradient():
                 -4.13181080289514, -2.34226739863660, -3.44356159392859,
                  2.85007173009739, -2.64884892757600,  0.71010806424206,
             ],
-        },
-        "driver": "gradient",
-        "model": {
-            "method": "GFN1-xTB",
-        },
-        "extras": {
-            "important": {
-                "config": "do not drop",
-            },
-        },
-    }
-    dipole_moment = np.array(
-        [-1.46493585, -2.03036834,  2.08330405]
-    )
-    gradient = np.array([
-        [ 0.009232625741587227,  0.003155461859519221,  0.002442986999241168],
-        [-0.011856864082491841, -0.001160759424710484, -0.001479499047578632],
-        [ 0.003451262987231787,  0.000215308710760728,  0.003730567708416359],
-        [ 0.003799388943258326, -0.004765860859119094,  0.007885211727762723],
-        [-0.000379213106866044, -0.002675726930398858,  0.001107252098240491],
-        [-0.007936554347068041,  0.005513289713065560, -0.010832254028311825],
-        [ 0.006084605665938956,  0.013967585988624595, -0.009310025918892868],
-        [-0.003220049379416426, -0.003946107654179984, -0.003740489224738476],
-        [ 0.006756157759172355,  0.000984515116819424,  0.007424736434524648],
-        [-0.030710275643265804, -0.004788736649680724,  0.009562034140682116],
-        [ 0.008109832723283130,  0.003419009494804033,  0.001692916089380574],
-        [ 0.005703460535291335, -0.009863992151429374,  0.001725512568523476],
-        [ 0.011742825276516265, -0.002780169889933200, -0.001075047642530233],
-        [-0.007336820690528053, -0.002159490005562796, -0.004872570579801525],
-        [-0.000541853527432064,  0.000671321722173119, -0.003239422092578492],
-        [ 0.007101471144788836,  0.004214350959247828, -0.001021909232339549],
-    ])
+        }
 
-    atomic_result = run_qcschema(qcel.models.AtomicInput(**atomic_input))
-
-    assert atomic_result.success
-    assert approx(atomic_result.properties.return_energy, abs=thr) == -33.63768565903155
-    assert approx(atomic_result.properties.scf_dipole_moment, abs=thr) == dipole_moment
-    assert approx(atomic_result.return_result, abs=thr) == gradient
-    assert atomic_result.extras['important'] == atomic_input['extras']['important']
-
-
-def test_gfn2xtb_gradient():
-    """Use QCSchema to perform a GFN2-xTB calculation on a mindless molecule"""
-    thr = 1.0e-7
-
-    atomic_input = {
-        "molecule": {
+    if name == "mindless_gfn2":
+        return {
             "symbols": [
                 "H", "F", "P", "Al", "H", "H", "Al", "B",
                 "Li", "P", "O", "H", "H", "B", "S", "H",
@@ -171,12 +98,254 @@ def test_gfn2xtb_gradient():
                 -1.59355304432499,  3.69176153150419,  2.87878226787916,
                  4.34858700256050,  2.39171478113440, -2.61802993563738,
             ],
+        }
+
+    if name == "cns_hessian":
+        return {
+            "symbols": [
+                "C", "C", "C", "C", "N", "C", "S", "H", "H", "H", "H", "H",
+            ],
+            "geometry": [
+                -2.56745685564671, -0.02509985979910,  0.00000000000000,
+                -1.39177582455797,  2.27696188880014,  0.00000000000000,
+                 1.27784995624894,  2.45107479759386,  0.00000000000000,
+                 2.62801937615793,  0.25927727028120,  0.00000000000000,
+                 1.41097033661123, -1.99890996077412,  0.00000000000000,
+                -1.17186102298849, -2.34220576284180,  0.00000000000000,
+                -2.39505990368378, -5.22635838332362,  0.00000000000000,
+                 2.41961980455457, -3.62158019253045,  0.00000000000000,
+                -2.51744374846065,  3.98181713686746,  0.00000000000000,
+                 2.24269048384775,  4.24389473203647,  0.00000000000000,
+                 4.66488984573956,  0.17907568006409,  0.00000000000000,
+                -4.60044244782237, -0.17794734637413,  0.00000000000000,
+            ],
+        }
+
+    if name == "li4c4h12":
+        return {
+            "symbols": [
+                "Li", "Li", "Li", "Li", "C", "C", "C", "C",
+                "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H",
+            ],
+            "geometry": [
+                 1.58746019997201, -1.58746019997201,  1.58746019997201,
+                -1.58746019997201,  1.58746019997201,  1.58746019997201,
+                -1.58746019997201, -1.58746019997201, -1.58746019997201,
+                 1.58746019997201,  1.58746019997201, -1.58746019997201,
+                -2.38500089414639, -2.38500089414639,  2.38500089414639,
+                 2.38500089414639, -2.38500089414639, -2.38500089414639,
+                -2.38500089414639,  2.38500089414639, -2.38500089414639,
+                 2.38500089414639,  2.38500089414639,  2.38500089414639,
+                -4.43487372589517, -2.13523102374668,  2.13523102374668,
+                -2.13523102374668, -4.43487372589517,  2.13523102374668,
+                -2.13523102374668, -2.13523102374668,  4.43487372589517,
+                 2.13523102374668,  4.43487372589517,  2.13523102374668,
+                 2.13523102374668,  2.13523102374668,  4.43487372589517,
+                 4.43487372589517,  2.13523102374668,  2.13523102374668,
+                 2.13523102374668, -2.13523102374668, -4.43487372589517,
+                 4.43487372589517, -2.13523102374668, -2.13523102374668,
+                 2.13523102374668, -4.43487372589517, -2.13523102374668,
+                -2.13523102374668,  2.13523102374668, -4.43487372589517,
+                -4.43487372589517,  2.13523102374668, -2.13523102374668,
+                -2.13523102374668,  4.43487372589517, -2.13523102374668,
+            ],
+        }
+
+    if name == "cold_fusion":
+        return {
+            "symbols": [
+                "Li", "Li", "Li", "Li",
+            ],
+            "geometry": [
+                -1.58746019997201,  1.58746019997201,  1.58746019997201,
+                -1.58746019997201,  1.58746019997201,  1.58746019997201,
+                -1.58746019997201, -1.58746019997201, -1.58746019997201,
+                 1.58746019997201,  1.58746019997201, -1.58746019997201,
+            ],
+            "validated": True,
+        }
+
+    if name == "cation":
+        return {
+            "symbols": [
+                "C", "N", "C", "N", "C", "C", "C", "H",
+                "H", "H", "H", "H", "H", "H", "H", "H",
+            ],
+            "geometry": [
+                 0.048282499,     0.057183108,     0.173514640,
+                 0.048282499,     0.057183108,     2.785682877,
+                 2.460933466,     0.057183108,     3.599550067,
+                 3.991384751,    -0.221116838,     1.583647072,
+                 2.540755491,    -0.118599203,    -0.586344180,
+                -2.061048549,     0.828021237,     4.403571784,
+                 6.721736451,     0.210496578,     1.725659980,
+                 3.058786077,     0.070940314,     5.557211706,
+                 3.368228708,    -0.207680886,    -2.461916123,
+                -1.684652926,     0.148551360,    -0.921487085,
+                -3.836824062,     0.378984547,     3.432611673,
+                -1.962159188,    -0.217412975,     6.192197434,
+                -1.859660450,     2.870361499,     4.747464119,
+                 7.499472079,    -0.877758825,     3.310818833,
+                 7.584906591,    -0.429156772,    -0.047375431,
+                 7.008294500,     2.247696785,     2.037956097,
+            ],
+            "molecular_charge": +1,
+        }
+
+    if name == "anion":
+        return {
+            "symbols": [
+                "O", "C", "C", "F", "O", "F", "H",
+            ],
+            "geometry": [
+                 4.877023733,    -3.909030492,     1.796260143,
+                 6.112318716,    -2.778558610,     0.091330457,
+                 7.360520527,    -4.445334728,    -1.932830640,
+                 7.978801077,    -6.767751279,    -1.031771494,
+                 6.374499300,    -0.460299457,    -0.213142194,
+                 5.637581753,    -4.819746139,    -3.831249370,
+                 9.040657008,    -3.585225944,    -2.750722946,
+            ],
+            "molecular_charge": -1,
+        }
+
+    raise ValueError(f"Unknown molecule name: {name}")
+
+
+def get_atomic_input(
+    version: int,
+    molecule: Dict[str, Any],
+    driver: str,
+    method: str,
+    keywords: Optional[Dict[str, Any]] = None,
+    extras: Optional[Dict[str, Any]] = None,
+    qcel_object: bool = False,
+):
+    keywords = {} if keywords is None else keywords
+    extras = {} if extras is None else extras
+
+    if version == 1:
+        input_data = {
+            "molecule": molecule,
+            "driver": driver,
+            "model": {
+                "method": method,
+            },
+            "keywords": keywords,
+            "extras": extras,
+        }
+        if qcel_object:
+            return qcel_v1.AtomicInput(**input_data)
+        return input_data
+
+    if version == 2:
+        input_data = {
+            "molecule": molecule,
+            "specification": {
+                "driver": driver,
+                "model": {
+                    "method": method,
+                },
+                "keywords": keywords,
+            },
+            "extras": extras,
+        }
+        if qcel_object:
+            return qcel_v2.AtomicInput(**input_data)
+        return input_data
+
+    raise ValueError(f"Unsupported version: {version}")
+
+
+@pytest.fixture(params=[pytest.param(1, marks=v1_available), pytest.param(2, marks=v2_available)])
+def qcsk_version(request):
+    return request.param
+
+
+def test_gfn2xtb_energy(qcsk_version: int):
+    """Use QCSchema to calculate the energy of a halogen bond compound"""
+    thr = 1.0e-7
+
+    atomic_input = get_atomic_input(
+        version=qcsk_version,
+        molecule=get_molecule("halogen_bond"),
+        driver="energy",
+        method="GFN2-xTB",
+        keywords={
+            "accuracy": 1.0,
+            "electronic_temperature": 300.0,
+            "max_iterations": 50,
+            "solvent": "none",
         },
-        "driver": "gradient",
-        "model": {
-            "method": "GFN2-xTB",
+        qcel_object=True,
+    )
+    dipole_moment = np.array(
+        [0.3345115197707647, -1.0701017905608206, -1.2299212343599290]
+    )
+
+    atomic_result = run_qcschema(atomic_input)
+
+    assert atomic_result.success
+    assert approx(atomic_result.return_result, abs=thr) == -26.60185037124828
+    assert approx(atomic_result.properties.scf_dipole_moment, abs=thr) == dipole_moment
+
+
+def test_gfn1xtb_gradient(qcsk_version: int):
+    """Use QCSchema to perform a GFN1-xTB calculation on a mindless molecule"""
+    thr = 1.0e-7
+
+    entry = {"config": "do not drop"}
+    atomic_input = get_atomic_input(
+        version=qcsk_version,
+        molecule=get_molecule("mindless_gfn1"),
+        driver="gradient",
+        method="GFN1-xTB",
+        extras={
+            "important": entry
         },
-    }
+        qcel_object=True,
+    )
+    dipole_moment = np.array(
+        [-1.46493585, -2.03036834,  2.08330405]
+    )
+    gradient = np.array([
+        [ 0.009232625741587227,  0.003155461859519221,  0.002442986999241168],
+        [-0.011856864082491841, -0.001160759424710484, -0.001479499047578632],
+        [ 0.003451262987231787,  0.000215308710760728,  0.003730567708416359],
+        [ 0.003799388943258326, -0.004765860859119094,  0.007885211727762723],
+        [-0.000379213106866044, -0.002675726930398858,  0.001107252098240491],
+        [-0.007936554347068041,  0.005513289713065560, -0.010832254028311825],
+        [ 0.006084605665938956,  0.013967585988624595, -0.009310025918892868],
+        [-0.003220049379416426, -0.003946107654179984, -0.003740489224738476],
+        [ 0.006756157759172355,  0.000984515116819424,  0.007424736434524648],
+        [-0.030710275643265804, -0.004788736649680724,  0.009562034140682116],
+        [ 0.008109832723283130,  0.003419009494804033,  0.001692916089380574],
+        [ 0.005703460535291335, -0.009863992151429374,  0.001725512568523476],
+        [ 0.011742825276516265, -0.002780169889933200, -0.001075047642530233],
+        [-0.007336820690528053, -0.002159490005562796, -0.004872570579801525],
+        [-0.000541853527432064,  0.000671321722173119, -0.003239422092578492],
+        [ 0.007101471144788836,  0.004214350959247828, -0.001021909232339549],
+    ])
+
+    atomic_result = run_qcschema(atomic_input)
+
+    assert atomic_result.success
+    assert approx(atomic_result.properties.return_energy, abs=thr) == -33.63768565903155
+    assert approx(atomic_result.properties.scf_dipole_moment, abs=thr) == dipole_moment
+    assert approx(atomic_result.return_result, abs=thr) == gradient
+    assert atomic_result.extras["important"] == entry
+
+
+def test_gfn2xtb_gradient(qcsk_version: int):
+    """Use QCSchema to perform a GFN2-xTB calculation on a mindless molecule"""
+    thr = 1.0e-7
+
+    atomic_input = get_atomic_input(
+        version=qcsk_version,
+        molecule=get_molecule("mindless_gfn2"),
+        driver="gradient",
+        method="GFN2-xTB",
+    )
     dipole_moment = np.array(
         [ 0.1965142200947483, -0.8278681912495578, -1.9355888893816835]
     )
@@ -207,33 +376,15 @@ def test_gfn2xtb_gradient():
     assert approx(atomic_result.return_result, abs=thr) == gradient
 
 
-def test_gfn1xtb_hessian():
+def test_gfn1xtb_hessian(qcsk_version: int):
     """Hessian not available from API, should fail"""
 
-    atomic_input = qcel.models.AtomicInput(
-        molecule = {
-            "symbols": [
-                "C", "C", "C", "C", "N", "C", "S", "H", "H", "H", "H", "H",
-            ],
-            "geometry": [
-                -2.56745685564671, -0.02509985979910,  0.00000000000000,
-                -1.39177582455797,  2.27696188880014,  0.00000000000000,
-                 1.27784995624894,  2.45107479759386,  0.00000000000000,
-                 2.62801937615793,  0.25927727028120,  0.00000000000000,
-                 1.41097033661123, -1.99890996077412,  0.00000000000000,
-                -1.17186102298849, -2.34220576284180,  0.00000000000000,
-                -2.39505990368378, -5.22635838332362,  0.00000000000000,
-                 2.41961980455457, -3.62158019253045,  0.00000000000000,
-                -2.51744374846065,  3.98181713686746,  0.00000000000000,
-                 2.24269048384775,  4.24389473203647,  0.00000000000000,
-                 4.66488984573956,  0.17907568006409,  0.00000000000000,
-                -4.60044244782237, -0.17794734637413,  0.00000000000000,
-            ],
-        },
-        driver = "hessian",
-        model = {
-            "method": "GFN1-xTB",
-        },
+    atomic_input = get_atomic_input(
+        version=qcsk_version,
+        molecule=get_molecule("cns_hessian"),
+        driver="hessian",
+        method="GFN1-xTB",
+        qcel_object=True,
     )
 
     atomic_result = run_qcschema(atomic_input)
@@ -241,44 +392,16 @@ def test_gfn1xtb_hessian():
     assert not atomic_result.success
 
 
-def test_gfn2xtb_properties():
-    """Also test properties run type once, should just return everything
-    available as a dict"""
+def test_gfn2xtb_properties(qcsk_version: int):
+    """Also test properties run type once, should just return everything available as a dict"""
     thr = 1.0e-5
 
-    atomic_input = qcel.models.AtomicInput(
-        molecule = {
-            "symbols": [
-                "Li", "Li", "Li", "Li", "C", "C", "C", "C",
-                "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H",
-            ],
-            "geometry": [
-                 1.58746019997201, -1.58746019997201,  1.58746019997201,
-                -1.58746019997201,  1.58746019997201,  1.58746019997201,
-                -1.58746019997201, -1.58746019997201, -1.58746019997201,
-                 1.58746019997201,  1.58746019997201, -1.58746019997201,
-                -2.38500089414639, -2.38500089414639,  2.38500089414639,
-                 2.38500089414639, -2.38500089414639, -2.38500089414639,
-                -2.38500089414639,  2.38500089414639, -2.38500089414639,
-                 2.38500089414639,  2.38500089414639,  2.38500089414639,
-                -4.43487372589517, -2.13523102374668,  2.13523102374668,
-                -2.13523102374668, -4.43487372589517,  2.13523102374668,
-                -2.13523102374668, -2.13523102374668,  4.43487372589517,
-                 2.13523102374668,  4.43487372589517,  2.13523102374668,
-                 2.13523102374668,  2.13523102374668,  4.43487372589517,
-                 4.43487372589517,  2.13523102374668,  2.13523102374668,
-                 2.13523102374668, -2.13523102374668, -4.43487372589517,
-                 4.43487372589517, -2.13523102374668, -2.13523102374668,
-                 2.13523102374668, -4.43487372589517, -2.13523102374668,
-                -2.13523102374668,  2.13523102374668, -4.43487372589517,
-                -4.43487372589517,  2.13523102374668, -2.13523102374668,
-                -2.13523102374668,  4.43487372589517, -2.13523102374668,
-            ],
-        },
-        driver = "properties",
-        model = {
-            "method": "GFN2-xTB",
-        },
+    atomic_input = get_atomic_input(
+        version=qcsk_version,
+        molecule=get_molecule("li4c4h12"),
+        driver="properties",
+        method="GFN2-xTB",
+        qcel_object=True,
     )
     charges = np.array([
          0.45632539,  0.45632539,  0.45632539,  0.45632539, -0.45436293,
@@ -290,37 +413,34 @@ def test_gfn2xtb_properties():
     atomic_result = run_qcschema(atomic_input)
 
     assert atomic_result.success
-    assert approx(atomic_result.return_result['mulliken_charges'], abs=thr) == charges
+    assert approx(atomic_result.return_result["mulliken_charges"], abs=thr) == charges
 
 
-def test_gfn2xtb_error():
+def test_gfn2xtb_error(qcsk_version: int):
     """Pass some cold fusion input to xtb, see how this turns out.
 
     xtb should be perfectly capable of detecting and rejecting this input
-    by itself"""
+    by itself
+    """
 
-    atomic_input = qcel.models.AtomicInput(
-        molecule = {
-            "symbols": [
-                "Li", "Li", "Li", "Li",
-            ],
-            "geometry": [
-                -1.58746019997201,  1.58746019997201,  1.58746019997201,
-                -1.58746019997201,  1.58746019997201,  1.58746019997201,
-                -1.58746019997201, -1.58746019997201, -1.58746019997201,
-                 1.58746019997201,  1.58746019997201, -1.58746019997201,
-            ],
-            "validated": True,  # Force a nuclear fusion input, to make xtb fail
-        },
-        driver = "properties",
-        model = {
-            "method": "GFN2-xTB",
-        },
+    atomic_input = get_atomic_input(
+        version=qcsk_version,
+        molecule=get_molecule("cold_fusion"),
+        driver="properties",
+        method="GFN2-xTB",
+        qcel_object=True,
     )
-    error = qcel.models.ComputeError(
-        error_type='runtime_error',
-        error_message='Setup of molecular structure failed:\n-1- xtb_api_newMolecule: Could not generate molecular structure',
+
+    error = dict(
+        error_type="runtime_error",
+        error_message="Setup of molecular structure failed:\n-1- xtb_api_newMolecule: Could not generate molecular structure",
     )
+    if qcsk_version == 1:
+        error = qcel_v1.ComputeError(**error)
+    elif qcsk_version == 2:
+        error = qcel_v2.ComputeError(**error)
+    else:
+        raise RuntimeError(f"QCSchema v{qcsk_version} NYI")
 
     atomic_result = run_qcschema(atomic_input)
 
@@ -328,38 +448,27 @@ def test_gfn2xtb_error():
     assert atomic_result.error == error
 
 
-def test_unknown_method():
+def test_unknown_method(qcsk_version: int):
     """Select an unknown method in the atomic input"""
 
-    atomic_input = qcel.models.AtomicInput(
-        molecule = {
-            "symbols": [
-                "C", "C", "C", "C", "N", "C", "S", "H", "H", "H", "H", "H",
-            ],
-            "geometry": [
-                -2.56745685564671, -0.02509985979910,  0.00000000000000,
-                -1.39177582455797,  2.27696188880014,  0.00000000000000,
-                 1.27784995624894,  2.45107479759386,  0.00000000000000,
-                 2.62801937615793,  0.25927727028120,  0.00000000000000,
-                 1.41097033661123, -1.99890996077412,  0.00000000000000,
-                -1.17186102298849, -2.34220576284180,  0.00000000000000,
-                -2.39505990368378, -5.22635838332362,  0.00000000000000,
-                 2.41961980455457, -3.62158019253045,  0.00000000000000,
-                -2.51744374846065,  3.98181713686746,  0.00000000000000,
-                 2.24269048384775,  4.24389473203647,  0.00000000000000,
-                 4.66488984573956,  0.17907568006409,  0.00000000000000,
-                -4.60044244782237, -0.17794734637413,  0.00000000000000,
-            ],
-        },
-        driver = "energy",
-        model = {
-            "method": "GFN-xTB",  # GFN-xTB should be GFN1-xTB
-        },
+    atomic_input = get_atomic_input(
+        version=qcsk_version,
+        molecule=get_molecule("cns_hessian"),
+        driver="energy",
+        method="GFN-xTB",
+        qcel_object=True,
     )
-    error = qcel.models.ComputeError(
-        error_type='input_error',
-        error_message='Invalid method GFN-xTB provided in model',
+
+    error = dict(
+        error_type="input_error",
+        error_message="Invalid method GFN-xTB provided in model",
     )
+    if qcsk_version == 1:
+        error = qcel_v1.ComputeError(**error)
+    elif qcsk_version == 2:
+        error = qcel_v2.ComputeError(**error)
+    else:
+        raise RuntimeError(f"QCSchema v{qcsk_version} NYI")
 
     atomic_result = run_qcschema(atomic_input)
 
@@ -367,44 +476,20 @@ def test_unknown_method():
     assert atomic_result.error == error
 
 
-def test_gfn2xtb_solvation():
+def test_gfn2xtb_solvation(qcsk_version: int):
     """Solvate a kation of an ionic liquid with GFN2-xTB/GBSA"""
     thr = 1.0e-7
 
-    atomic_input = qcel.models.AtomicInput(
-        molecule = {
-            "symbols": [
-                "C", "N", "C", "N", "C", "C", "C", "H",
-                "H", "H", "H", "H", "H", "H", "H", "H",
-            ],
-            "geometry": [
-                 0.048282499,     0.057183108,     0.173514640,
-                 0.048282499,     0.057183108,     2.785682877,
-                 2.460933466,     0.057183108,     3.599550067,
-                 3.991384751,    -0.221116838,     1.583647072,
-                 2.540755491,    -0.118599203,    -0.586344180,
-                -2.061048549,     0.828021237,     4.403571784,
-                 6.721736451,     0.210496578,     1.725659980,
-                 3.058786077,     0.070940314,     5.557211706,
-                 3.368228708,    -0.207680886,    -2.461916123,
-                -1.684652926,     0.148551360,    -0.921487085,
-                -3.836824062,     0.378984547,     3.432611673,
-                -1.962159188,    -0.217412975,     6.192197434,
-                -1.859660450,     2.870361499,     4.747464119,
-                 7.499472079,    -0.877758825,     3.310818833,
-                 7.584906591,    -0.429156772,    -0.047375431,
-                 7.008294500,     2.247696785,     2.037956097,
-            ],
-            "molecular_charge": +1,
-        },
-        driver = "energy",
-        model = {
-            "method": "GFN2-xTB",
-        },
-        keywords = {
+    atomic_input = get_atomic_input(
+        version=qcsk_version,
+        molecule=get_molecule("cation"),
+        driver="energy",
+        method="GFN2-xTB",
+        keywords={
             "maxiter": 50,
             "solvent": "water",
         },
+        qcel_object=True,
     )
 
     atomic_result = run_qcschema(atomic_input)
@@ -413,34 +498,20 @@ def test_gfn2xtb_solvation():
     assert approx(atomic_result.return_result, abs=thr) == -20.8299331650115
 
 
-def test_gfn1xtb_solvation():
+def test_gfn1xtb_solvation(qcsk_version: int):
     """Solvate an anion of an ionic liquid with GFN1-xTB/GBSA"""
     thr = 1.0e-7
 
-    atomic_input = qcel.models.AtomicInput(
-        molecule = {
-            "symbols": [
-                "O", "C", "C", "F", "O", "F", "H",
-            ],
-            "geometry": [
-                 4.877023733,    -3.909030492,     1.796260143,
-                 6.112318716,    -2.778558610,     0.091330457,
-                 7.360520527,    -4.445334728,    -1.932830640,
-                 7.978801077,    -6.767751279,    -1.031771494,
-                 6.374499300,    -0.460299457,    -0.213142194,
-                 5.637581753,    -4.819746139,    -3.831249370,
-                 9.040657008,    -3.585225944,    -2.750722946,
-            ],
-            "molecular_charge": -1,
-        },
-        driver = "energy",
-        model = {
-            "method": "GFN1-xTB",
-        },
-        keywords = {
+    atomic_input = get_atomic_input(
+        version=qcsk_version,
+        molecule=get_molecule("anion"),
+        driver="energy",
+        method="GFN1-xTB",
+        keywords={
             "maxiter": 50,
             "solvent": "THF",
         },
+        qcel_object=True,
     )
 
     atomic_result = run_qcschema(atomic_input)
@@ -453,34 +524,16 @@ def test_gfn1xtb_solvation():
     pytest.param("muted", id="muted flag"),
     pytest.param(0, id="muted value")
 ])
-def test_verbosity(verbosity):
+def test_verbosity(qcsk_version: int, verbosity):
     """Make sure out put is only saved when requested."""
 
-    atomic_input = qcel.models.AtomicInput(
-        molecule={
-            "symbols": [
-                "C", "C", "C", "C", "N", "C", "S", "H", "H", "H", "H", "H",
-            ],
-            "geometry": [
-                -2.56745685564671, -0.02509985979910, 0.00000000000000,
-                -1.39177582455797, 2.27696188880014, 0.00000000000000,
-                1.27784995624894, 2.45107479759386, 0.00000000000000,
-                2.62801937615793, 0.25927727028120, 0.00000000000000,
-                1.41097033661123, -1.99890996077412, 0.00000000000000,
-                -1.17186102298849, -2.34220576284180, 0.00000000000000,
-                -2.39505990368378, -5.22635838332362, 0.00000000000000,
-                2.41961980455457, -3.62158019253045, 0.00000000000000,
-                -2.51744374846065, 3.98181713686746, 0.00000000000000,
-                2.24269048384775, 4.24389473203647, 0.00000000000000,
-                4.66488984573956, 0.17907568006409, 0.00000000000000,
-                -4.60044244782237, -0.17794734637413, 0.00000000000000,
-            ],
-        },
+    atomic_input = get_atomic_input(
+        version=qcsk_version,
+        molecule=get_molecule("cns_hessian"),
         driver="energy",
-        model={
-            "method": "GFN1-xTB",
-        },
-        keywords={"verbosity": verbosity}
+        method="GFN1-xTB",
+        keywords={"verbosity": verbosity},
+        qcel_object=True,
     )
 
     atomic_result = run_qcschema(atomic_input)

--- a/xtb/test_libxtb.py
+++ b/xtb/test_libxtb.py
@@ -16,11 +16,11 @@
 # along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 
-from pkg_resources import parse_version
+from packaging.version import Version
 from xtb import API_VERSION
 from xtb.libxtb import get_api_version
 
 
 def test_api_version():
     """Ensure that the API version is compatible."""
-    assert parse_version(get_api_version()) >= parse_version(API_VERSION)
+    assert Version(get_api_version()) >= Version(API_VERSION)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

### Description
<!-- Provide a brief description of the PR's purpose here. -->
Update QCSchema interface for v2 and Python 3.14. Input v1 returns v1; input v2 returns v2. Enables Python 3.14.

### Changelog description
<!-- Provide a brief single sentence for the changelog. -->

### Status
<!-- Please, add tests and documentation for your contribution. -->
- [x] Updated qcschema interface and tests for v1 or v2 in the style of dftd3, dftd4, and tblite
- [x] CI is working on my fork, except for mypy linting
  - not building xtb library but using the conda package. Not the best, but the linked repositories may need updating in sync.
  - updated a lot of GHA actions and extended Py versions and dropped py37
  -  replaced `manylinux` that was erroring on node and basic C++ libs with a `wheels` step related to dftd4. linux only
- [x] arranged for ase and qcelemental to be optional for testing, like dftd3/4
- [x] slightly loosened testing for ASE optimizations
- [x] updated from pkg_resources to packaging
